### PR TITLE
feat: bump to 1.19.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,6 +50,17 @@ env:
   # yamllint disable-line rule:line-length
   DOCKER_PASSWORD: "ENCRYPTED[!ba694a81b388c14ab792c378a7f32a36e3d216a393c4b67dcc7e3eadf76d7ec24d9b9ffe7c4cde7cea4abcd4b655e959!]"
 
+docker_builder:
+  name: "Build Image"
+  depends_on:
+    - "Lint Shell"
+    - "Lint Containerfile"
+    - "Scan Containerfile"
+  build_script: "docker image build
+                --cache-from $DOCKER_HUB_IMAGE
+                --tag $DOCKER_HUB_IMAGE:$CIRRUS_CHANGE_IN_REPO
+                container/"
+
 # Release
 devel_docker_builder:
   name: "Deliver Devel Image"
@@ -57,10 +68,7 @@ devel_docker_builder:
             $CIRRUS_TAG == '' &&
             $CIRRUS_ENVIRONMENT != 'CLI'"
   depends_on:
-    - "Lint Shell"
-    - "Lint Containerfile"
-    - "Scan Containerfile"
-  info_script: "docker info"
+    - "Build Image"
   login_script: "docker login
                 --username $DOCKER_USERNAME
                 --password $DOCKER_PASSWORD
@@ -79,10 +87,7 @@ stable_docker_builder:
             $CIRRUS_TAG != '' &&
             $CIRRUS_ENVIRONMENT != 'CLI'"
   depends_on:
-    - "Lint Shell"
-    - "Lint Containerfile"
-    - "Scan Containerfile"
-  info_script: "docker info"
+    - "Build"
   login_script: "docker login
                 --username $DOCKER_USERNAME
                 --password $DOCKER_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This file is the changelog of
 
 ## [Unreleased]
 
+## [1.19.2] - 20220904
+
+Bump minecraft version to 1.19.2.
+
+### Added
+
+- dedicated build step in CI/CD for local build testing
+
+### Changed
+
+- version: 1.19.2
+- url to new 1.19.2 uri
+
+## [1.19.1] - 20220728
+
+Bump minecraft version to 1.19.1.
+
+### Changed
+
+- version: 1.19.1
+
 ## [1.19.0] - 20220716
 
 This release includes Minecraft 1.19 and also some minor adjustments for the

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,8 +2,8 @@
 FROM docker.io/library/alpine:3
 
 # Minecraft Version used in entrypoint
-ENV MC_VER="1.19.1"
-ENV MC_URL="https://piston-data.mojang.com/v1/objects/8399e1211e95faa421c1507b322dbeae86d604df/server.jar"
+ENV MC_VER="1.19.2"
+ENV MC_URL="https://piston-data.mojang.com/v1/objects/f69c284232d7c7580bd89a5a4931c3581eae1378/server.jar"
 
 # Adding some while-true-do.io information
 LABEL io.while-true-do.site="https://while-true-do.io"


### PR DESCRIPTION
Bumped the MC server to 1.19.2. Also added a new
build step that builds locally with a commit sha.